### PR TITLE
docs: use single quotes for contains()

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ jobs:
             echo "$file has changed"
           done
 
-      - if: contains(steps.changed-files.outputs.files, "package-lock.json")
+      - if: contains(steps.changed-files.outputs.files, 'package-lock.json')
         run: |
           echo "package-lock.json has changed"
 


### PR DESCRIPTION
Had to debug, seems that `contains(steps.changed-files.outputs.files, "package-lock.json")` is (no longer?) supported by the runner engine, it works with `contains(steps.changed-files.outputs.files, 'package-lock.json')`